### PR TITLE
EFTI-664 container exits with error status if pmode upload fails

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -23,7 +23,7 @@ services:
       - TLS_KEYSTORE_PASSWORD=tls-keystore-h1
       - TLS_TRUSTSTORE_PASSWORD=tls-truststore-h1
       - DOMIBUS_AUTH_UNSECURELOGINALLOWED=true
-    restart: always
+    restart: no
     ports:
       - "127.0.0.1:10443:8443"
     depends_on:
@@ -84,7 +84,7 @@ services:
       - ACTIVEMQ_BROKER_NAME=broker1,broker2
       - ACTIVEMQ_USERNAME=admin
       - ACTIVEMQ_PASSWORD=admin
-    restart: always
+    restart: no
     depends_on:
       - db-h2
       - harmony-jms-broker1
@@ -122,7 +122,7 @@ services:
       - ACTIVEMQ_BROKER_NAME=broker1,broker2
       - ACTIVEMQ_USERNAME=admin
       - ACTIVEMQ_PASSWORD=admin
-    restart: always
+    restart: no
     depends_on:
       - db-h2
       - harmony-jms-broker1

--- a/files/bin/aggregate_entrypoint.sh
+++ b/files/bin/aggregate_entrypoint.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 
+set -e # Exit immediately if a command exits with a non-zero status.
+set -u # Treat unset variables as an error when substituting.
+
 /opt/efti/bin/init_stores.sh "$EFTI_AP_KEYSTORE_BASE64" "$EFTI_AP_TRUSTSTORE_BASE64" "$EFTI_TLS_KEYSTORE_BASE64" "$EFTI_TLS_TRUSTSTORE_BASE64"
 /opt/efti/bin/init_wsplugin.sh $EFTI_WSPLUGIN_PROPERTIES_BASE64
+
 /opt/efti/bin/wait_for_harmony.sh /opt/efti/bin/init_pmode.sh "$ADMIN_PASSWORD" "$EFTI_PMODE_ADMIN_PASSWORD" "$EFTI_PMODE_BASE64" &
-/opt/efti/bin/harmony_entrypoint.sh
+PMODE_INIT_PID=$!
+
+# Start harmony in background so that we may easily check wait_for_harmony.sh status
+/opt/efti/bin/harmony_entrypoint.sh &
+HARMONY_PID=$!
+
+# Note: this will wait for wait_for_harmony.sh to finish (error or timeout) even if harmony_entrypoint.sh
+# exited (probably with an error status).
+wait $PMODE_INIT_PID
+PMODE_INIT_STATUS=$?
+
+if [[ $PMODE_INIT_STATUS -ne 0 ]]; then
+  echo "Got exit status $PMODE_INIT_STATUS from wait_for_harmony.sh/init_pmode.sh"
+  exit $PMODE_INIT_STATUS
+fi
+
+# Wait for harmony process to finish
+wait $HARMONY_PID

--- a/files/bin/init_pmode.sh
+++ b/files/bin/init_pmode.sh
@@ -38,6 +38,7 @@ echo "##########################################################################
 echo "Login to harmony as admin user"
 echo "#######################################################################################"
 curl -X POST \
+  --fail-with-body \
   --cookie-jar "$COOKIE_FILE" \
   -H 'Content-Type: application/json' \
   -d '{"username" : "'"$ADMIN_USER"'", "password" : "'"$HARMONY_ADMIN_PWD"'"}' \
@@ -52,6 +53,7 @@ echo "Check if pmode plugin user has already been setup"
 echo "#######################################################################################"
 USERS_QUERY_FILE=$(mktemp)
 curl -X GET \
+  --fail-with-body \
   -b "$COOKIE_FILE" \
   -H "X-XSRF-TOKEN: $XSRF_TOKEN" \
   -o "$USERS_QUERY_FILE" \
@@ -69,6 +71,7 @@ else
   echo "Create pmode plugin user"
   echo "#######################################################################################"
   curl -X PUT \
+    --fail-with-body \
     -b "$COOKIE_FILE" \
     -H 'Content-Type: application/json' \
     -H "X-XSRF-TOKEN: $XSRF_TOKEN" \
@@ -81,4 +84,10 @@ echo
 echo "#######################################################################################"
 echo "Upload pmode from $PMODE_PATH"
 echo "#######################################################################################"
-curl -u pmode_admin:"$PMODE_ADMIN_PWD" --basic -F file=@"$PMODE_PATH" --insecure "$PROTOCOL://localhost:$PORT/ext/pmode?description=pmode"
+curl \
+  --fail-with-body \
+  -u pmode_admin:"$PMODE_ADMIN_PWD" \
+  --basic \
+  -F file=@"$PMODE_PATH" \
+  --insecure \
+  "$PROTOCOL://localhost:$PORT/ext/pmode?description=pmode"


### PR DESCRIPTION
This required the "--fail-with-body" parameter for curl and exit status checking in aggregate_entrypoint.sh.